### PR TITLE
[Security]upgrade checkstyle version

### DIFF
--- a/streaming/java/pom.xml
+++ b/streaming/java/pom.xml
@@ -192,7 +192,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>8.19</version>
+              <version>8.29</version>
             </dependency>
           </dependencies>
           <executions>


### PR DESCRIPTION
GHSA-763g-fqq7-48wg
Moderate severity
Vulnerable versions: < 8.29
Patched version: 8.29
Due to an incomplete fix for CVE-2019-9658, checkstyle was still vulnerable to XML External Entity (XXE) Processing.

Impact
User: Build Maintainers
This vulnerability probably doesn't impact Maven/Gradle users as, in most cases, these builds are processing files that are trusted, or pre-vetted by a pull request reviewer before being run on internal CI infrastructure.

User: Static Analysis as a Service
If you operate a site/service that parses "untrusted" Checkstyle XML configuration files, you are vulnerable to this and should patch.

Note from the discoverer of the original CVE-2019-9658: