### PR TITLE
[MockTest]Fix mock consumed buf release early

### DIFF
--- a/streaming/java/streaming-runtime/src/test/java/io/ray/streaming/runtime/demo/WordCountTest.java
+++ b/streaming/java/streaming-runtime/src/test/java/io/ray/streaming/runtime/demo/WordCountTest.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Math;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;


### PR DESCRIPTION
Buffer of MockQueueItem might be released before consumed, which only occurs in mac os(perphas gcc or malloc in linux cache item in memory and would not release it immediatly). 
So this pr try to fix this issue and make mock producer and mock consumer access queue info map thread-safely.