### PR TITLE
update bazel version and enable java build

### DIFF
--- a/.github/workflows/macos_building.yml
+++ b/.github/workflows/macos_building.yml
@@ -30,4 +30,4 @@ jobs:
             sudo sh scripts/install-bazel.sh
 
     - name: Build streaming and test
-      run: sh -c "bash streaming/buildtest.sh"
+      run: sh -c "bash streaming/buildtest.sh --test_categories=streaming_cpp"

--- a/.github/workflows/ubuntu_building.yml
+++ b/.github/workflows/ubuntu_building.yml
@@ -21,5 +21,8 @@ jobs:
             apt-get install -yq wget gcc g++ openjdk-8-jdk python3.7 zlib1g-dev zip
             sh scripts/install-bazel.sh
 
-    - name: Build streaming and test
-      run: sh -c "bash streaming/buildtest.sh"
+    - name: Streaming java test
+      run: sh -c "bash streaming/buildtest.sh --test_categories=streaming_java"
+
+    - name: Streaming cpp test
+      run: sh -c "bash streaming/buildtest.sh --test_categories=streaming_cpp"

--- a/scripts/install-bazel.sh
+++ b/scripts/install-bazel.sh
@@ -24,9 +24,9 @@ esac
 echo "platform is ${platform}"
 
 if [ "${platform}" = "darwin" ]; then
-    wget "https://github.com/bazelbuild/bazel/releases/download/5.0.0/bazel-5.0.0-installer-darwin-x86_64.sh" -O bazel-5.0.0-installer-darwin-x86_64.sh
+    wget "https://github.com/bazelbuild/bazel/releases/download/5.1.0/bazel-5.1.0-installer-darwin-x86_64.sh" -O bazel-5.0.0-installer-darwin-x86_64.sh
     sh bazel-5.0.0-installer-darwin-x86_64.sh
 else
-    wget "https://github.com/bazelbuild/bazel/releases/download/5.0.0/bazel_5.0.0-linux-x86_64.deb" -O bazel_5.0.0-linux-x86_64.deb
+    wget "https://github.com/bazelbuild/bazel/releases/download/5.1.0/bazel_5.1.0-linux-x86_64.deb" -O bazel_5.0.0-linux-x86_64.deb
     dpkg -i bazel_5.0.0-linux-x86_64.deb
 fi

--- a/scripts/install-bazel.sh
+++ b/scripts/install-bazel.sh
@@ -25,8 +25,8 @@ echo "platform is ${platform}"
 
 if [ "${platform}" = "darwin" ]; then
     wget "https://github.com/bazelbuild/bazel/releases/download/5.1.0/bazel-5.1.0-installer-darwin-x86_64.sh" -O bazel-5.1.0-installer-darwin-x86_64.sh
-    sh bazel-5.0.0-installer-darwin-x86_64.sh
+    sh bazel-5.1.0-installer-darwin-x86_64.sh
 else
     wget "https://github.com/bazelbuild/bazel/releases/download/5.1.0/bazel_5.1.0-linux-x86_64.deb" -O bazel_5.1.0-linux-x86_64.deb
-    dpkg -i bazel_5.0.0-linux-x86_64.deb
+    dpkg -i bazel_5.1.0-linux-x86_64.deb
 fi

--- a/scripts/install-bazel.sh
+++ b/scripts/install-bazel.sh
@@ -24,9 +24,9 @@ esac
 echo "platform is ${platform}"
 
 if [ "${platform}" = "darwin" ]; then
-    wget "https://github.com/bazelbuild/bazel/releases/download/5.1.0/bazel-5.1.0-installer-darwin-x86_64.sh" -O bazel-5.0.0-installer-darwin-x86_64.sh
+    wget "https://github.com/bazelbuild/bazel/releases/download/5.1.0/bazel-5.1.0-installer-darwin-x86_64.sh" -O bazel-5.1.0-installer-darwin-x86_64.sh
     sh bazel-5.0.0-installer-darwin-x86_64.sh
 else
-    wget "https://github.com/bazelbuild/bazel/releases/download/5.1.0/bazel_5.1.0-linux-x86_64.deb" -O bazel_5.0.0-linux-x86_64.deb
+    wget "https://github.com/bazelbuild/bazel/releases/download/5.1.0/bazel_5.1.0-linux-x86_64.deb" -O bazel_5.1.0-linux-x86_64.deb
     dpkg -i bazel_5.0.0-linux-x86_64.deb
 fi

--- a/streaming/WORKSPACE
+++ b/streaming/WORKSPACE
@@ -10,6 +10,15 @@ http_archive(
         sha256 = "69a2dc6e0d78e14758ef60ab2eb34b99c88f3e1c6292b1181dbf83e164272032",
 )
 
+http_archive(
+    name = "platforms",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz",
+    ],
+    sha256 = "379113459b0feaf6bfbb584a91874c065078aa673222846ac765f86661c27407",
+)
+
 
 load("@com_github_ray_project_ray//bazel:ray_deps_setup.bzl", "ray_deps_setup")
 


### PR DESCRIPTION
Bazel build exception hapends when selecting jni platform previously https://github.com/ray-project/mobius/issues/29.
According to bazel issue tracing comment : https://github.com/bazelbuild/bazel/issues/14097#issuecomment-1068981527, I have to try update platform version to 0.0.5.

Dev can run specific test in buildtest script, like
```shell
bash buildtest.sh --test_categories=streaming_cpp
```
means going to build and run streaming cpp tests.

By the way, bazel tool version also upgrade to 5.1.0.