### PR TITLE
[Lint]upgrade click to 8.0.2 for black lint workaround

### DIFF
--- a/.github/workflows/ubuntu_lint.yml
+++ b/.github/workflows/ubuntu_lint.yml
@@ -25,8 +25,9 @@ jobs:
     - name: Init Env
       run:  |
             apt-get update && DEBIAN_FRONTEND="noninteractive" TZ="America/New_York" apt-get install -y tzdata
-            apt-get install -yq openjdk-8-jdk wget gcc g++ python3.7 zlib1g-dev zip
+            apt-get install -yq openjdk-8-jdk wget gcc g++ python3.8 zlib1g-dev zip
             apt-get install -yq python3-pip maven
+            python3 -m pip3 install --upgrade click==8.0.2
             sh scripts/install-bazel.sh
 
     - name: Prepare format tools


### PR DESCRIPTION
To fix black lint painc
```
Traceback (most recent call last):
  File "/usr/local/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/usr/local/lib/python3.8/dist-packages/black/__init__.py", line 1372, in patched_main
    patch_click()
  File "/usr/local/lib/python3.8/dist-packages/black/__init__.py", line 1358, in patch_click
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (/usr/local/lib/python3.8/dist-packages/click/__init__.py)
```